### PR TITLE
MakeRelativePath returns file system path instead of URI escaped path

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,11 +27,12 @@ build_script:
 after_test:
   - cmd: >- 
       "%USERPROFILE%\.nuget\packages\OpenCover\4.6.519\tools\OpenCover.Console.exe"
-      -register:user
-      -target:"C:\Program Files\dotnet\dotnet.exe" -filter:"+[Cabinet*]* -[Cabinet.Tests*]*"
-      -output:"artifacts\coverage.xml"
-      -searchdirs:"test\Cabinet.Tests\bin\Release\net46"
+      -register:Path32
+      -target:"C:\Program Files\dotnet\dotnet.exe" 
       -targetargs:"test -f net46 -c Release test\Cabinet.Tests\Cabinet.Tests.csproj"
+      -output:"artifacts\coverage.xml"
+      -filter:"+[Cabinet*]* -[Cabinet.Tests*]*"
+      -searchdirs:"test\Cabinet.Tests\bin\Release\net46"
 
   - cmd: >-
       IF DEFINED COVERALLS_REPO_TOKEN "%USERPROFILE%\.nuget\packages\coveralls.io\1.3.4\tools\coveralls.net.exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ version: 1.1.0-{branch}-{build}
 
 environment:
     COVERALLS_REPO_TOKEN:
-       secure: "taR6Lo8ItJ2wz57yn2n8wwkTuiULP+n8EicEJck1CaxeDGLWHmZzw6NX1a7RR0Cd"
+       secure: 9zsHagg7ZmF/Z1MnTaSeFk7xaNeYHuw+OyaULmL+vW5pFllN1UkyjO4Wn/pj759j
 
 configuration: Release
 

--- a/src/Cabinet.FileSystem/PathExtensions.cs
+++ b/src/Cabinet.FileSystem/PathExtensions.cs
@@ -58,13 +58,6 @@ namespace Cabinet.FileSystem {
             return dir1Path.Equals(dir2Path, StringComparison.OrdinalIgnoreCase);
         }
 
-        public static bool IsSubDirectoryOf(this string subPath, string basePath) {
-            var subDir = GetDirectoryInfoBase(subPath);
-            var baseDir = GetDirectoryInfoBase(basePath);
-
-            return subDir.IsChildOf(baseDir);
-        }
-
         public static bool IsChildOf(this DirectoryInfoBase subDir, DirectoryInfoBase baseDir) {
             var isChild = false;
 

--- a/test/Cabinet.Tests/Cabinet.Tests.csproj
+++ b/test/Cabinet.Tests/Cabinet.Tests.csproj
@@ -30,34 +30,38 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
     <PackageReference Include="AWSSDK.Core" Version="3.1.4.4" />
     <PackageReference Include="AWSSDK.S3" Version="3.1.3.11" />
     <PackageReference Include="coveralls.io" Version="1.3.4" />
+    <PackageReference Include="Microsoft.NETCore.Targets" Version="3.1.0" />
     <PackageReference Include="Moq" Version="4.2.1510.2205" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="System.IO.Abstractions" Version="2.0.0.123" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="2.0.0.123" />
-    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
-    <PackageReference Include="xunit.abstractions" Version="2.0.0" />
-    <PackageReference Include="xunit.assert" Version="2.1.0" />
-    <PackageReference Include="xunit.core" Version="2.1.0" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.1.0" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.1.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.1.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.0.2" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="3.1.3" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="xunit" Version="2.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.0.2" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Cabinet.Tests/Core/Progress/WriteProgressExtensionFacts.cs
+++ b/test/Cabinet.Tests/Core/Progress/WriteProgressExtensionFacts.cs
@@ -27,7 +27,7 @@ namespace Cabinet.Tests.Core.Progress {
         }
 
         [Theory]
-        [MemberData("GetProgressData")]
+        [MemberData(nameof(GetProgressData))]
         public void ProgressPercentage(long bytesWritten, long? totalBytes, double? expected) {
             var progress = new WriteProgress("key", bytesWritten, totalBytes);
 
@@ -36,8 +36,8 @@ namespace Cabinet.Tests.Core.Progress {
             Assert.Equal(expected, percentage);
         }
 
-        public static object[] GetProgressData() {
-            return new object[] {
+        public static object[][] GetProgressData() {
+            return new [] {
                 new object[] { 50, (long?)0, null },
                 new object[] { 100, (long?)50, (double?)2 },
                 new object[] { 50, (long?)100, (double?)0.5 },

--- a/test/Cabinet.Tests/FileSystem/Config/FileSystemConfigConverterFacts.cs
+++ b/test/Cabinet.Tests/FileSystem/Config/FileSystemConfigConverterFacts.cs
@@ -44,8 +44,8 @@ namespace Cabinet.Tests.FileSystem.Config {
         }
 
 
-        public static object[] GetConfigStrings() {
-            return new object[] {
+        public static object[][] GetConfigStrings() {
+            return new [] {
                 new object[] { @"{
                     ""dir"": ""~/App_Data/Uploads"",
                     ""createIfNotExists"": true

--- a/test/Cabinet.Tests/FileSystem/FileSystemStorageProviderFacts.cs
+++ b/test/Cabinet.Tests/FileSystem/FileSystemStorageProviderFacts.cs
@@ -594,10 +594,10 @@ namespace Cabinet.Tests.FileSystem {
         public static object[][] GetSafeTestPaths() {
             return new [] {
                 new object[] { @"c:\foo", @"file.txt", @"c:\foo\file.txt", @"file.txt" },
-                new object[] { @"c:\foo", @"bar\file.txt", @"c:\foo\bar\file.txt", @"bar/file.txt" },
-                new object[] { @"c:\foo", @"bar\baz", @"c:\foo\bar\baz", @"bar/baz" },
-                new object[] { @"c:\foo", @"./bar/baz", @"c:\foo\bar\baz", @"bar/baz" },
-                new object[] { @"c:\foo", @"../foo/bar/baz", @"c:\foo\bar\baz", @"bar/baz" },
+                new object[] { @"c:\foo", @"bar\file.txt", @"c:\foo\bar\file.txt", @"bar\file.txt" },
+                new object[] { @"c:\foo", @"bar\baz", @"c:\foo\bar\baz", @"bar\baz" },
+                new object[] { @"c:\foo", @"./bar/baz", @"c:\foo\bar\baz", @"bar\baz" },
+                new object[] { @"c:\foo", @"../foo/bar/baz", @"c:\foo\bar\baz", @"bar\baz" },
             };
         }
 
@@ -621,10 +621,10 @@ namespace Cabinet.Tests.FileSystem {
             return new [] {
                 new object[] { baseDir, files, "", true, new Dictionary<string, ItemType> {
                         { @"file.txt", ItemType.File },
-                        { @"bar/one.txt", ItemType.File },
-                        { @"bar/two.txt", ItemType.File },
-                        { @"bar/baz/three", ItemType.File },
-                        { @"foo/one.txt", ItemType.File },
+                        { @"bar\one.txt", ItemType.File },
+                        { @"bar\two.txt", ItemType.File },
+                        { @"bar\baz\three", ItemType.File },
+                        { @"foo\one.txt", ItemType.File },
                     }
                 },
                 new object[] { baseDir, files, "", false, new Dictionary<string, ItemType> {
@@ -634,19 +634,19 @@ namespace Cabinet.Tests.FileSystem {
                     }
                 },
                 new object[] { baseDir, files, "bar", true, new Dictionary<string, ItemType> {
-                        { @"bar/one.txt", ItemType.File },
-                        { @"bar/two.txt", ItemType.File },
-                        { @"bar/baz/three", ItemType.File },
+                        { @"bar\one.txt", ItemType.File },
+                        { @"bar\two.txt", ItemType.File },
+                        { @"bar\baz\three", ItemType.File },
                     }
                 },
                 new object[] { baseDir, files, "bar", false, new Dictionary<string, ItemType> {
-                        { @"bar/baz", ItemType.Directory },
-                        { @"bar/one.txt", ItemType.File },
-                        { @"bar/two.txt", ItemType.File },
+                        { @"bar\baz", ItemType.Directory },
+                        { @"bar\one.txt", ItemType.File },
+                        { @"bar\two.txt", ItemType.File },
                     }
                 },
                 new object[] { baseDir, files, @"bar\baz", false, new Dictionary<string, ItemType> {
-                        { @"bar/baz/three", ItemType.File },
+                        { @"bar\baz\three", ItemType.File },
                     }
                 },
             };

--- a/test/Cabinet.Tests/FileSystem/FileSystemStorageProviderFacts.cs
+++ b/test/Cabinet.Tests/FileSystem/FileSystemStorageProviderFacts.cs
@@ -591,8 +591,8 @@ namespace Cabinet.Tests.FileSystem {
             return config;
         }
 
-        public static object[] GetSafeTestPaths() {
-            return new object[] {
+        public static object[][] GetSafeTestPaths() {
+            return new [] {
                 new object[] { @"c:\foo", @"file.txt", @"c:\foo\file.txt", @"file.txt" },
                 new object[] { @"c:\foo", @"bar\file.txt", @"c:\foo\bar\file.txt", @"bar/file.txt" },
                 new object[] { @"c:\foo", @"bar\baz", @"c:\foo\bar\baz", @"bar/baz" },
@@ -601,13 +601,13 @@ namespace Cabinet.Tests.FileSystem {
             };
         }
 
-        public static object[] GetMoveTestPaths() {
-            return new object[] {
+        public static object[][] GetMoveTestPaths() {
+            return new [] {
                 new object[] { @"c:\foo", @"from.txt", @"c:\foo\from.txt", @"to.txt", @"c:\foo\to.txt" },
             };
         }
 
-        public static object[] GetListTestPaths() {
+        public static object[][] GetListTestPaths() {
             string baseDir = @"C:\data";
 
             var files = new Dictionary<string, string> {
@@ -618,7 +618,7 @@ namespace Cabinet.Tests.FileSystem {
                 { @"foo\one.txt", "one" },
             };
             
-            return new object[] {
+            return new [] {
                 new object[] { baseDir, files, "", true, new Dictionary<string, ItemType> {
                         { @"file.txt", ItemType.File },
                         { @"bar/one.txt", ItemType.File },

--- a/test/Cabinet.Tests/FileSystem/PathExtensionFacts.cs
+++ b/test/Cabinet.Tests/FileSystem/PathExtensionFacts.cs
@@ -69,8 +69,8 @@ namespace Cabinet.Tests.FileSystem {
             Assert.Equal(isChildOf, actualResult);
         }
 
-        public static object[] GetTestPaths() {
-            return new object[] {
+        public static object[][] GetTestPaths() {
+            return new [] {
                 new object[] { @"c:\foo", @"c:", false, false },
                 new object[] { @"c:\foo", @"c:\", true, false },
                 new object[] { @"c:\foo", @"c:\foo", false, true },

--- a/test/Cabinet.Tests/FileSystem/PathExtensionFacts.cs
+++ b/test/Cabinet.Tests/FileSystem/PathExtensionFacts.cs
@@ -1,11 +1,7 @@
 ﻿using Cabinet.FileSystem;
 using Moq;
 using System;
-using System.Collections.Generic;
 using System.IO.Abstractions;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Cabinet.Tests.FileSystem {
@@ -14,8 +10,9 @@ namespace Cabinet.Tests.FileSystem {
         [Theory]
         [InlineData(@"c:\foo", @"C:\foo\bar", @"bar")]
         [InlineData(@"c:\foo\", @"C:\foo\bar", @"bar")]
-        [InlineData(@"c:\foo\", @"C:\foo\bar\baz.txt", @"bar/baz.txt")]
-        public void Make_Relative(string basePath, string subPath, string expectedRelativePath) {
+        [InlineData(@"c:\foo\", @"C:\foo\bar\baz.txt", @"bar\baz.txt")]
+        [InlineData(@"c:\foo\", @"C:\foo\foo bar\baz.txt", @"foo bar\baz.txt")]
+        public void MakeRelativeTo(string basePath, string subPath, string expectedRelativePath) {
             string actual = subPath.MakeRelativeTo(basePath);
             Assert.Equal(expectedRelativePath, actual);
         }

--- a/test/Cabinet.Tests/FileSystem/PathExtensionFacts.cs
+++ b/test/Cabinet.Tests/FileSystem/PathExtensionFacts.cs
@@ -58,14 +58,6 @@ namespace Cabinet.Tests.FileSystem {
             Assert.Equal(isSameDir, actualResult);
         }
 
-        [Theory]
-        [MemberData("GetTestPaths")]
-        public void Is_SubDirectory_Of(string subPath, string basePath, bool isChildOf, bool isSameDir) {
-            var actualResult = subPath.IsSubDirectoryOf(basePath);
-
-            Assert.Equal(isChildOf, actualResult);
-        }
-
         public static object[][] GetTestPaths() {
             return new [] {
                 new object[] { @"c:\foo", @"c:", false, false },

--- a/test/Cabinet.Tests/FileSystem/Results/DeleteResultFacts.cs
+++ b/test/Cabinet.Tests/FileSystem/Results/DeleteResultFacts.cs
@@ -38,8 +38,8 @@ namespace Cabinet.Tests.FileSystem.Results {
             Assert.Equal(msg, result.GetErrorMessage());
         }
 
-        public static object[] GetExceptionMessages() {
-            return new object[] {
+        public static object[][] GetExceptionMessages() {
+            return new [] {
                 new object[] { new DirectoryNotFoundException(), "Could not find the file" },
                 new object[] { new PathTooLongException(), "The path is too long. The path must be less than 248 characters and file name less than 260 characters." },
                 new object[] { new UnauthorizedAccessException(), "Could not delete the file" },

--- a/test/Cabinet.Tests/FileSystem/Results/MoveResultFacts.cs
+++ b/test/Cabinet.Tests/FileSystem/Results/MoveResultFacts.cs
@@ -47,8 +47,8 @@ namespace Cabinet.Tests.FileSystem.Results {
             Assert.Equal(msg, result.GetErrorMessage());
         }
 
-        public static object[] GetExceptionMessages() {
-            return new object[] {
+        public static object[][] GetExceptionMessages() {
+            return new [] {
                 new object[] { new UnauthorizedAccessException(), "Could not move the file" },
                 new object[] { new PathTooLongException(), "The path is too long. The path must be less than 248 characters and file name less than 260 characters." },
                 new object[] { new DirectoryNotFoundException(), "The source or destination directory could not be found" },

--- a/test/Cabinet.Tests/FileSystem/Results/SaveResultFacts.cs
+++ b/test/Cabinet.Tests/FileSystem/Results/SaveResultFacts.cs
@@ -69,8 +69,8 @@ namespace Cabinet.Tests.FileSystem.Results {
             Assert.Equal(msg, result.GetErrorMessage());
         }
 
-        public static object[] GetExceptionMessages() {
-            return new object[] {
+        public static object[][] GetExceptionMessages() {
+            return new [] {
                 new object[] { new UnauthorizedAccessException(), "Could not save the file" },
                 new object[] { new PathTooLongException(), "The path is too long. The path must be less than 248 characters and file name less than 260 characters." },
                 new object[] { new DirectoryNotFoundException(), "The destination directory could not be found" },

--- a/test/Cabinet.Tests/Migrator/Migration/MigratorStorageProviderFacts.cs
+++ b/test/Cabinet.Tests/Migrator/Migration/MigratorStorageProviderFacts.cs
@@ -269,8 +269,8 @@ namespace Cabinet.Tests.Migrator.Migration {
             }
         }
 
-        public static object[] GetListKeysData() {
-            return new object[] {
+        public static object[][] GetListKeysData() {
+            return new [] {
                 new object[] { "", true, new string[] { }, new string[] { }, new string[] { } },
                 new object[] { "", true, new string[] { "one", "two", "three" }, new string[] { }, new string[] { "one", "two", "three" } },
                 new object[] { "", true, new string[] { }, new string[] { "one", "two", "three" }, new string[] { "one", "two", "three" } },

--- a/test/Cabinet.Tests/Migrator/Results/MoveResultFacts.cs
+++ b/test/Cabinet.Tests/Migrator/Results/MoveResultFacts.cs
@@ -60,8 +60,8 @@ namespace Cabinet.Tests.Migrator.Results {
             Assert.Equal(msg, result.GetErrorMessage());
         }
 
-        public static object[] GetExceptionMessages() {
-            return new object[] {
+        public static object[][] GetExceptionMessages() {
+            return new [] {
                 new object[] { new Exception("test"), "System.Exception: test" },
             };
         }

--- a/test/Cabinet.Tests/S3/AmazonS3StorageProviderFacts.cs
+++ b/test/Cabinet.Tests/S3/AmazonS3StorageProviderFacts.cs
@@ -600,7 +600,7 @@ namespace Cabinet.Tests.S3 {
             return config;
         }
 
-        public static object[] GetTestS3Objects() {
+        public static object[][] GetTestS3Objects() {
             var s3Objects = new List<S3Object>() {
                 new S3Object() { Key = "file.txt", Size = 3, LastModified = DateTime.UtcNow.AddHours(-1) },
                 new S3Object() { Key = @"bar/one.txt", Size = 3, LastModified = DateTime.UtcNow.AddHours(-5) },
@@ -620,7 +620,7 @@ namespace Cabinet.Tests.S3 {
             var bazObjects = s3Objects.Where(o => o.Key.StartsWith(barBazPrefix)).ToList();
             var barDirectChildObjects = barObjects.Where(o => o.Key.StartsWith(barPrefix) && !o.Key.StartsWith(barBazPrefix + "/")).ToList();
 
-            return new object[] {
+            return new [] {
                 new object[] { "test-bucket", "",        "",        true, HttpStatusCode.OK, s3Objects,  "" },
                 new object[] { "test-bucket", "",        barPrefix, true, HttpStatusCode.OK, barObjects, barPrefix },
                 new object[] { "test-bucket", barPrefix, "",        true, HttpStatusCode.OK, barObjects, barPrefix },

--- a/test/Cabinet.Tests/S3/Config/AmazonS3ConfigConverterFacts.cs
+++ b/test/Cabinet.Tests/S3/Config/AmazonS3ConfigConverterFacts.cs
@@ -47,7 +47,7 @@ namespace Cabinet.Tests.S3.Config {
         }
 
 
-        public static object[] GetConfigStrings() {
+        public static object[][] GetConfigStrings() {
             string defaultKeyPrefix = null;
             string defaultDelimiter = AmazonS3CabinetConfig.DefaultDelimiter;
 
@@ -57,7 +57,7 @@ namespace Cabinet.Tests.S3.Config {
             Expression<Action<IAWSCredentialsFactory>> environmentVerify = (f) => f.GetEnvironmentCredentials();
             Expression<Action<IAWSCredentialsFactory>> environmentVariableVerify = (f) => f.GetEnvironmentVariableCredentials();
             
-            return new object[] { 
+            return new [] { 
                 //Types: basic, stored-profile, environment, environment-variable
                 new object[] { @"{
                     ""credentials"": {

--- a/test/Cabinet.Tests/S3/Results/DeleteResultFacts.cs
+++ b/test/Cabinet.Tests/S3/Results/DeleteResultFacts.cs
@@ -42,8 +42,8 @@ namespace Cabinet.Tests.S3.Results {
             Assert.Equal(msg, result.GetErrorMessage());
         }
 
-        public static object[] GetExceptionMessages() {
-            return new object[] {
+        public static object[][] GetExceptionMessages() {
+            return new [] {
                 new object[] { new Exception(), "System.Exception: Exception of type 'System.Exception' was thrown." },
             };
         }

--- a/test/Cabinet.Tests/S3/Results/MoveResultFacts.cs
+++ b/test/Cabinet.Tests/S3/Results/MoveResultFacts.cs
@@ -23,7 +23,7 @@ namespace Cabinet.Tests.S3.Results {
         [InlineData(HttpStatusCode.Forbidden, false, null)]
         [InlineData(HttpStatusCode.Unauthorized, false, "Access to the bucket is denied")]
         [InlineData(HttpStatusCode.InternalServerError, false, null)]
-        public void Sets_Success(HttpStatusCode code, bool success, string errorMsg) {
+        public void Sets_Code_Success(HttpStatusCode code, bool success, string errorMsg) {
             var result = new MoveResult("sourceKey", "destKey", code);
             Assert.Equal(success, result.Success);
             Assert.Equal(errorMsg, result.GetErrorMessage());
@@ -59,8 +59,8 @@ namespace Cabinet.Tests.S3.Results {
             Assert.Equal(msg, result.GetErrorMessage());
         }
 
-        public static object[] GetExceptionMessages() {
-            return new object[] {
+        public static object[][] GetExceptionMessages() {
+            return new [] {
                 new object[] { new Exception("test"), "test" },
             };
         }

--- a/test/Cabinet.Tests/S3/Results/SaveResultFacts.cs
+++ b/test/Cabinet.Tests/S3/Results/SaveResultFacts.cs
@@ -23,7 +23,7 @@ namespace Cabinet.Tests.S3.Results {
         [InlineData(HttpStatusCode.Forbidden, false, null)]
         [InlineData(HttpStatusCode.Unauthorized, false, "Access to the bucket is denied")]
         [InlineData(HttpStatusCode.InternalServerError, false, null)]
-        public void Sets_Success(HttpStatusCode code, bool success, string errorMsg) {
+        public void Sets_Code_Success(HttpStatusCode code, bool success, string errorMsg) {
             var result = new SaveResult("key", code);
             Assert.Equal(success, result.Success);
             Assert.Equal(errorMsg, result.GetErrorMessage());
@@ -82,8 +82,8 @@ namespace Cabinet.Tests.S3.Results {
             Assert.Equal(msg, result.GetErrorMessage());
         }
 
-        public static object[] GetExceptionMessages() {
-            return new object[] {
+        public static object[][] GetExceptionMessages() {
+            return new [] {
                 new object[] { new Exception("test"), "test" },
             };
         }


### PR DESCRIPTION
Previous logic returned a URI escaped path which is sometimes handled by the file system OK but not when URI unsafe characters are escaped.

e.g. A path of "c:\foo bar\foo.txt" relative to "c:\" would return "foo%20bar/foo.txt" (instead of "foo bar\foo.txt") which the file system sees as a different path which doesn't exist.